### PR TITLE
Accept separated validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ Import `ActionTypes` from the module.
 |`ActionTypes.SET_FIELD`|Set value for a field, then runs validation if enabled|
 |`ActionTypes.SET_FIELDS_BULK`|Set values for fields at once, then make all dirtiness flags false|
 |`ActionTypes.RESET_FIELDS`|Reset values on field with initial values|
-|`ActionTypes.ENABLE_ALL_VALIDATIONS`|Enable interactive validation and run validations for all fields|
+|`ActionTypes.ENABLE_VALIDATION`|Enable interactive validation for a specific field, and run validations immediately|
+|`ActionTypes.ENABLE_ALL_VALIDATIONS`|Enable interactive validation and run validations for all fields immediately|
 |`ActionTypes.VALIDATE_FIELDS`|Validate for each field that is enabled fro interactive validation|
 |`ActionTypes.SET_FIELDS_EDITABILITY`|Set editability flag for a field, disabled field is not updated nor validated|
 |`ActionTypes.SET_FIELDS_PRISTINE`|Make all dirtiness flags false|

--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ Import `ActionTypes` from the module.
 |`ActionTypes.SET_FIELD`|Set value for a field, then runs validation if enabled|
 |`ActionTypes.SET_FIELDS_BULK`|Set values for fields at once, then make all dirtiness flags false|
 |`ActionTypes.RESET_FIELDS`|Reset values on field with initial values|
-|`ActionTypes.ENABLE_VALIDATION`|Enable interactive validation for a specific field, and run validations immediately|
-|`ActionTypes.ENABLE_ALL_VALIDATIONS`|Enable interactive validation and run validations for all fields immediately|
-|`ActionTypes.VALIDATE_FIELDS`|Validate for each field that is enabled fro interactive validation|
+|`ActionTypes.ENABLE_VALIDATION`|Enable interactive validation for a specific field, and run validations on this field immediately|
+|`ActionTypes.ENABLE_ALL_VALIDATIONS`|Enable interactive validations for all fields and run all validations immediately|
+|`ActionTypes.VALIDATE_FIELDS`|Validate for each field that is enabled for interactive validation|
 |`ActionTypes.SET_FIELDS_EDITABILITY`|Set editability flag for a field, disabled field is not updated nor validated|
 |`ActionTypes.SET_FIELDS_PRISTINE`|Make all dirtiness flags false|
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ enum MutationTypes {
   SET_FIELD_EDITABILITY = "SET_FIELD_EDITABILITY",
   SET_FIELD_EDITABILITIES_BULK = "SET_FIELD_EDITABILITIES_BULK",
   SET_FIELD_DIRTINESS = "SET_FIELD_DIRTINESS",
+  ENABLE_VALIDATION = "ENABLE_VALIDATION",
   ENABLE_ALL_VALIDATIONS = "ENABLE_ALL_VALIDATIONS",
   SET_FIELDS_PRISTINE = "SET_FIELDS_PRISTINE"
 }
@@ -74,6 +75,7 @@ export enum ActionTypes {
   SET_FIELD_EDITABILITIES_BULK = "validatableStateSetFieldEditabilitiesBulk",
   RESET_FIELDS = "validatableStateResetFields",
   VALIDATE_FIELDS = "validatableStateValidateFields",
+  ENABLE_VALIDATION = "validatableStateEnableValidation",
   ENABLE_ALL_VALIDATIONS = "validatableStateEnableAllValidations",
   SET_FIELDS_PRISTINE = "validatableStateSetFieldsPristine"
 }
@@ -181,6 +183,10 @@ const buildModule = <S, F>(
       });
     },
 
+    [MutationTypes.ENABLE_VALIDATION] (state, name: keyof F) {
+      state.fields[name].isEnabledValidation = true;
+    },
+
     [MutationTypes.ENABLE_ALL_VALIDATIONS] (state) {
       (Object.keys(state.fields) as (keyof F)[]).forEach((fieldKey) => {
         state.fields[fieldKey].isEnabledValidation = true
@@ -245,6 +251,11 @@ const buildModule = <S, F>(
           }
         }
       });
+    },
+
+    async [ActionTypes.ENABLE_VALIDATION] <T extends keyof F> ({ dispatch, commit }, key: T) {
+      commit(MutationTypes.ENABLE_VALIDATION, key);
+      return dispatch(ActionTypes.VALIDATE_FIELDS);
     },
 
     async [ActionTypes.ENABLE_ALL_VALIDATIONS] ({ dispatch, commit }) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ interface FormField<T> {
   error: string | false;
   disabled: boolean;
   dirty: boolean;
-  isEnabledValidation: boolean;
+  validationEnabled: boolean;
 }
 
 const initialStateOfField = <T>(initialValue: T): FormField<T> => ({
@@ -13,7 +13,7 @@ const initialStateOfField = <T>(initialValue: T): FormField<T> => ({
   error: false,
   disabled: false,
   dirty: false,
-  isEnabledValidation: false
+  validationEnabled: false
 });
 
 interface ValidatableFieldsState<T> {
@@ -185,12 +185,12 @@ const buildModule = <S, F>(
     },
 
     [MutationTypes.ENABLE_VALIDATION] (state, name: keyof F) {
-      state.fields[name].isEnabledValidation = true;
+      state.fields[name].validationEnabled = true;
     },
 
     [MutationTypes.ENABLE_ALL_VALIDATIONS] (state) {
       (Object.keys(state.fields) as (keyof F)[]).forEach((fieldKey) => {
-        state.fields[fieldKey].isEnabledValidation = true
+        state.fields[fieldKey].validationEnabled = true
       });
     },
 
@@ -238,10 +238,10 @@ const buildModule = <S, F>(
             const validatorResult = validatorForField(getters[GetterTypes.FIELD_VALUES], getters);
 
             if (validatorResult instanceof Array) {
-              if (validatorResult[1].instant === true || state.fields[name].isEnabledValidation) {
+              if (validatorResult[1].instant === true || state.fields[name].validationEnabled) {
                 errorForField = validatorResult[0](getters[GetterTypes.FIELD_VALUES], getters);
               }
-            } else if (state.fields[name].isEnabledValidation) {
+            } else if (state.fields[name].validationEnabled) {
               errorForField = validatorResult;
             }
             return !!errorForField;

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ export type FieldDirtinesses<F> = {
 };
 
 export type SetFieldAction<F> = <T extends keyof F>(payload: { name: T ; value: F[T]; }) => void;
+export type EnableValidationAction<F> = <T extends keyof F>(payload: T) => void;
 
 export enum GetterTypes {
   ALL_FIELDS_VALID = "validatableStateAllFieldsValid",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -28,25 +28,27 @@ describe("vuex-validatable-field-module", () => {
     it("The store gets initial values and setup meta info on under the internal key", () => {
       const store = setupStore();
       expect(store.state[moduleInternalKey]).toEqual({
-        validates: false,
         fields: {
           age: {
             value: null,
             error: false,
             disabled: false,
-            dirty: false
+            dirty: false,
+            isEnabledValidation: false
           },
           name: {
             value: null,
             error: false,
             disabled: false,
-            dirty: false
+            dirty: false,
+            isEnabledValidation: false
           },
           subscribed: {
             value: false,
             error: false,
             disabled: false,
-            dirty: false
+            dirty: false,
+            isEnabledValidation: false
           }
         }
       });
@@ -83,11 +85,15 @@ describe("vuex-validatable-field-module", () => {
       expect(store.state[moduleInternalKey].fields.subscribed.value).toBe(true);
     });
 
-    it("ENABLE_ALL_VALIDATIONS updates all validateInteractively flags as true", () => {
+    it("ENABLE_ALL_VALIDATIONS updates all isEnabledValidation flag as true", () => {
       const store = setupStore();
-      expect(store.state[moduleInternalKey].validates).toBe(false);
+      expect(
+        Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
+      ).toEqual([false, false, false])
       store.commit("ENABLE_ALL_VALIDATIONS");
-      expect(store.state[moduleInternalKey].validates).toBe(true);
+      expect(
+        Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
+      ).toEqual([true, true, true])
     });
 
     it("SET_FIELD_DIRTINESS updates drity flag", () => {
@@ -367,7 +373,7 @@ describe("vuex-validatable-field-module", () => {
     });
 
     describe("VALIDATE_FIELDS", () => {
-      describe("state.validates is flagged", () => {
+      describe("isEnabledValidation is flagged", () => {
         it("store error message if validator returns", async () => {
           const mockAge = jest.fn().mockReturnValue("error message on age");
           const store = setupStore({
@@ -510,11 +516,15 @@ describe("vuex-validatable-field-module", () => {
     });
 
     describe("ENABLE_ALL_VALIDATIONS", () => {
-      it("enable validateInteractively flag on the specific field", () => {
+      it("enable all isEnabledValidation flag", () => {
         const store = setupStore();
-        expect(store.state[moduleInternalKey].validates).toBe(false);
+        expect(
+          Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
+        ).toEqual([false, false, false])
         store.dispatch(ActionTypes.ENABLE_ALL_VALIDATIONS);
-        expect(store.state[moduleInternalKey].validates).toBe(true);
+        expect(
+          Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
+        ).toEqual([true, true, true])
       });
     });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -34,21 +34,21 @@ describe("vuex-validatable-field-module", () => {
             error: false,
             disabled: false,
             dirty: false,
-            isEnabledValidation: false
+            validationEnabled: false
           },
           age: {
             value: null,
             error: false,
             disabled: false,
             dirty: false,
-            isEnabledValidation: false
+            validationEnabled: false
           },
           subscribed: {
             value: false,
             error: false,
             disabled: false,
             dirty: false,
-            isEnabledValidation: false
+            validationEnabled: false
           }
         }
       });
@@ -85,25 +85,25 @@ describe("vuex-validatable-field-module", () => {
       expect(store.state[moduleInternalKey].fields.subscribed.value).toBe(true);
     });
 
-    it("ENABLE_ALL_VALIDATIONS updates all isEnabledValidation flag as true", () => {
+    it("ENABLE_ALL_VALIDATIONS updates all validationEnabled flag as true", () => {
       const store = setupStore();
       expect(
-        Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
+        Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].validationEnabled)
       ).toEqual([false, false, false])
       store.commit("ENABLE_ALL_VALIDATIONS");
       expect(
-        Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
+        Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].validationEnabled)
       ).toEqual([true, true, true])
     });
 
-    it("ENABLE_VALIDATION updates isEnabledValidation flag on a specified field as true", () => {
+    it("ENABLE_VALIDATION updates validationEnabled flag on a specified field as true", () => {
       const store = setupStore();
       expect(
-        Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
+        Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].validationEnabled)
       ).toEqual([false, false, false])
       store.commit("ENABLE_VALIDATION", "subscribed");
       expect(
-        Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
+        Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].validationEnabled)
       ).toEqual([false, false, true])
     });
 
@@ -384,7 +384,7 @@ describe("vuex-validatable-field-module", () => {
     });
 
     describe("VALIDATE_FIELDS", () => {
-      describe("isEnabledValidation is flagged", () => {
+      describe("validationEnabled is flagged", () => {
         it("store error message if validator returns", async () => {
           const mockAge = jest.fn().mockReturnValue("error message on age");
           const store = setupStore({
@@ -527,27 +527,27 @@ describe("vuex-validatable-field-module", () => {
     });
 
     describe("ENABLE_ALL_VALIDATIONS", () => {
-      it("enable all isEnabledValidation flag", () => {
+      it("enable all validationEnabled flag", () => {
         const store = setupStore();
         expect(
-          Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
+          Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].validationEnabled)
         ).toEqual([false, false, false])
         store.dispatch(ActionTypes.ENABLE_ALL_VALIDATIONS);
         expect(
-          Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
+          Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].validationEnabled)
         ).toEqual([true, true, true])
       });
     });
 
     describe("ENABLE_VALIDATION", () => {
-      it("enable isEnabledValidation flag on a specified field", () => {
+      it("enable validationEnabled flag on a specified field", () => {
         const store = setupStore();
         expect(
-          Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
+          Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].validationEnabled)
         ).toEqual([false, false, false])
         store.dispatch(ActionTypes.ENABLE_VALIDATION, "age");
         expect(
-          Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
+          Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].validationEnabled)
         ).toEqual([false, true, false])
       });
     });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -29,14 +29,14 @@ describe("vuex-validatable-field-module", () => {
       const store = setupStore();
       expect(store.state[moduleInternalKey]).toEqual({
         fields: {
-          age: {
+          name: {
             value: null,
             error: false,
             disabled: false,
             dirty: false,
             isEnabledValidation: false
           },
-          name: {
+          age: {
             value: null,
             error: false,
             disabled: false,
@@ -94,6 +94,17 @@ describe("vuex-validatable-field-module", () => {
       expect(
         Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
       ).toEqual([true, true, true])
+    });
+
+    it("ENABLE_VALIDATION updates isEnabledValidation flag on a specified field as true", () => {
+      const store = setupStore();
+      expect(
+        Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
+      ).toEqual([false, false, false])
+      store.commit("ENABLE_VALIDATION", "subscribed");
+      expect(
+        Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
+      ).toEqual([false, false, true])
     });
 
     it("SET_FIELD_DIRTINESS updates drity flag", () => {
@@ -525,6 +536,19 @@ describe("vuex-validatable-field-module", () => {
         expect(
           Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
         ).toEqual([true, true, true])
+      });
+    });
+
+    describe("ENABLE_VALIDATION", () => {
+      it("enable isEnabledValidation flag on a specified field", () => {
+        const store = setupStore();
+        expect(
+          Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
+        ).toEqual([false, false, false])
+        store.dispatch(ActionTypes.ENABLE_VALIDATION, "age");
+        expect(
+          Object.keys(store.state[moduleInternalKey].fields).map(key => store.state[moduleInternalKey].fields[key].isEnabledValidation)
+        ).toEqual([false, true, false])
       });
     });
 


### PR DESCRIPTION
- Have a flag for validation in each field `state.fields[*].isEnabledValidation` instead of `state.validates`
- Accept enabling validation for a specific field through `ActionTypes.ENABLE_VALIDATION`